### PR TITLE
fix: exports the cloudrun cpu_idle var and default to `true`

### DIFF
--- a/cloudrun/module/main.tf
+++ b/cloudrun/module/main.tf
@@ -99,6 +99,7 @@ resource "google_cloud_run_v2_service" "service" {
     containers {
       image = "${local.service_image_url}@${docker_registry_image.push.sha256_digest}"
       resources {
+        cpu_idle = var.cpu_idle
         limits = merge(
           {
             cpu    = var.cpus

--- a/cloudrun/module/variables.tf
+++ b/cloudrun/module/variables.tf
@@ -22,6 +22,12 @@ variable "memory_mb" {
   default     = 512
 }
 
+variable "cpu_idle" {
+  description = "Determines whether CPU is only allocated during requests"
+  type        = bool
+  default     = true
+}
+
 variable "cpus" {
   description = "The amount of cpus to allocate to the CloudRun service"
   type        = number


### PR DESCRIPTION
See the Terraform docs for why this is required: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service#cpu_idle-1
